### PR TITLE
Check for valid ip or port prior to connecting

### DIFF
--- a/Buildkite/scripts/base.sh
+++ b/Buildkite/scripts/base.sh
@@ -20,3 +20,18 @@ function buildkite-hook {
     buildkite-comment "Skipping, no hook script found at: $HOOK_SCRIPT_PATH"
   fi
 }
+
+function valid_ip {
+    local ip=${1-}
+
+    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        OIFS=$IFS
+        IFS='.' read -ra ip <<< "$ip"
+        IFS=$OIFS
+
+        if [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]; then
+            return 0
+        fi
+    fi
+    return -1
+}

--- a/Buildkite/scripts/bootstrap.sh
+++ b/Buildkite/scripts/bootstrap.sh
@@ -26,6 +26,16 @@ echo "$vm_id" > $CONNECTION_INFO_FILE
 vm_ip=$(echo $vm_info | jq -r '.ip')
 vm_ssh_port=$(echo $vm_info | jq -r '.ssh_port')
 
+if ! valid_ip $vm_ip; then
+    echo "Invalid ip: $vm_ip"
+    exit -1
+fi
+
+if [ -z "$vm_ssh_port" ]; then
+    echo "Invalid port: $vm_ssh_port"
+    exit -1
+fi
+
 echo "Waiting for sshd to be available"
 for i in $(seq 1 30); do
     if ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $ORKA_VM_USER@$vm_ip -p $vm_ssh_port "echo ok"  >/dev/null 2>/dev/null; then

--- a/GitHub/multiple-self-hosted-runners.md
+++ b/GitHub/multiple-self-hosted-runners.md
@@ -43,7 +43,7 @@ To set up multiple GitHub Actions runner, you need to:
     * You can find your token in the `Configure` section right after the `--token` flag.
 2. On a machine that has connectivity to your Orka environment:
     * Install [jq][jq] - a command-line JSON processor used by the provided scripts.
-    * Download [multiple-runners.sh](scripts/multiple-runners.sh) and [setup-runner.sh](scripts/setup-runner.sh) files in the same directory.
+    * Download [multiple-runners.sh](scripts/multiple-runners.sh), [setup-runner.sh](scripts/setup-runner.sh) and [base.sh](scripts/base.sh) files in the same directory.
     * Run the [multiple-runners.sh](scripts/multiple-runners.sh) script and provide the following arguments
         * `-u` or `--orka_user` - (Required) User used to authenticate with the Orka environment. Created by running `orka user create`.
         * `-p` or `--orka_password` - (Required) Password used to authenticate with the Orka environment. Created by running `orka user create`.

--- a/GitHub/scripts/base.sh
+++ b/GitHub/scripts/base.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+function valid_ip {
+    local ip=${1-}
+
+    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        OIFS=$IFS
+        IFS='.' read -ra ip <<< "$ip"
+        IFS=$OIFS
+
+        if [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]; then
+            return 0
+        fi
+    fi
+    return -1
+}

--- a/GitHub/scripts/multiple-runners.sh
+++ b/GitHub/scripts/multiple-runners.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-set -euo pipefail
-
 currentDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source ${currentDir}/base.sh
+
+set -euo pipefail
 
 orka_user=${ORKA_USER:-}
 orka_password=${ORKA_PASSWORD:-}
@@ -73,6 +74,16 @@ for i in $(seq 1 $runner_count); do
 
     vm_ip=$(echo $vm_info | jq -r '.ip')
     vm_ssh_port=$(echo $vm_info | jq -r '.ssh_port')
+
+    if ! valid_ip $vm_ip; then
+        echo "Invalid ip: $vm_ip"
+        exit -1
+    fi
+
+    if [ -z "$vm_ssh_port" ]; then
+        echo "Invalid port: $vm_ssh_port"
+        exit -1
+    fi
 
     echo "Waiting for sshd to be available"
     for i in $(seq 1 30); do

--- a/GitLab/scripts/base.sh
+++ b/GitLab/scripts/base.sh
@@ -10,3 +10,18 @@ ORKA_PASSWORD=${ORKA_PASSWORD:-$CUSTOM_ENV_ORKA_PASSWORD}
 ORKA_ENDPOINT=${ORKA_ENDPOINT:-$CUSTOM_ENV_ORKA_ENDPOINT}
 ORKA_VM_NAME=${ORKA_VM_NAME:-$CUSTOM_ENV_ORKA_VM_NAME}
 ORKA_VM_USER=${ORKA_VM_USER:-$CUSTOM_ENV_ORKA_VM_USER}
+
+function valid_ip {
+    local ip=${1-}
+
+    if [[ $ip =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+        OIFS=$IFS
+        IFS='.' read -ra ip <<< "$ip"
+        IFS=$OIFS
+
+        if [[ ${ip[0]} -le 255 && ${ip[1]} -le 255 && ${ip[2]} -le 255 && ${ip[3]} -le 255 ]]; then
+            return 0
+        fi
+    fi
+    return -1
+}

--- a/GitLab/scripts/prepare.sh
+++ b/GitLab/scripts/prepare.sh
@@ -20,6 +20,17 @@ echo "$vm_id" > $BUILD_ID
 
 vm_ip=$(echo $vm_info | jq -r '.ip')
 vm_ssh_port=$(echo $vm_info | jq -r '.ssh_port')
+
+if ! valid_ip $vm_ip; then
+    echo "Invalid ip: $vm_ip"
+    exit "$SYSTEM_FAILURE_EXIT_CODE"
+fi
+
+if [ -z "$vm_ssh_port" ]; then
+    echo "Invalid port: $vm_ssh_port"
+    exit "$SYSTEM_FAILURE_EXIT_CODE"
+fi
+
 echo "$vm_ip;$vm_ssh_port" > $CONNECTION_INFO_ID
 
 echo "Waiting for sshd to be available"


### PR DESCRIPTION
In some cases VMs are created without IP or port, which causes the connection to the machine to run forever.
Validate the ip and port and fail if needed