### PR TITLE
Add -l to /bin/bash

### DIFF
--- a/GitLab/scripts/run.sh
+++ b/GitLab/scripts/run.sh
@@ -10,4 +10,4 @@ IFS=';' read -ra info <<< "$connection_info"
 vm_ip=${info[0]}
 vm_ssh_port=${info[1]}
 
-ssh -i /root/.ssh/id_rsa -o ServerAliveInterval=60 -o ServerAliveCountMax=60 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $ORKA_VM_USER@$vm_ip -p $vm_ssh_port /bin/bash < "${1}"
+ssh -i /root/.ssh/id_rsa -o ServerAliveInterval=60 -o ServerAliveCountMax=60 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null $ORKA_VM_USER@$vm_ip -p $vm_ssh_port /bin/bash -l < "${1}"


### PR DESCRIPTION
The -l option makes "bash act as if it had been invoked as a login shell". Login shells read certain initialization files from your home directory, such as .bash_profile.

More info at: https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html