### PR TITLE
ORKA-865 Fix OSX actions runner download URL

### DIFF
--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -40,7 +40,7 @@ done
 
 mkdir $deploy_dir
 
-curl -o $deploy_dir/actions-runner.tar.gz https://githubassets.azureedge.net/runners/$version/actions-runner-osx-x64-$version.tar.gz 
+curl -o $deploy_dir/actions-runner.tar.gz https://github.com/actions/runner/releases/download/$version/actions-runner-osx-x64-$version.tar.gz
 cd $deploy_dir && tar xzf $deploy_dir/actions-runner.tar.gz
 
 $deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir


### PR DESCRIPTION
Jira issue: https://macstadium.atlassian.net/jira/software/projects/ORKA/boards/28?selectedIssue=ORKA-865

Currently, we're using the `githubassets.azureedge.net` which is not available anymore. Change it with the `github.com` when downloading the OSX runner.

Previously, `version=2.163.1 curl -o actions-runner.tar.gz https://githubassets.azureedge.net/runners/$version/actions-runner-osx-x64-$version.tar.gz` returns `curl: (6) Could not resolve host: githubassets.azureedge.net`

Now, `version=2.163.1 curl -o actions-runner.tar.gz https://github.com/actions/runner/releases/download/$version/actions-runner-osx-x64-$version.tar.gz` works as expected and downloads successfully the `actions-runner.tar.gz`