### PR TITLE
Fix curl command used to download the OSX actions runner

### DIFF
--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -40,7 +40,7 @@ done
 
 mkdir $deploy_dir
 
-curl -o $deploy_dir/actions-runner.tar.gz https://github.com/actions/runner/releases/download/$version/actions-runner-osx-x64-$version.tar.gz
+curl -o $deploy_dir/actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v$version/actions-runner-osx-x64-$version.tar.gz
 cd $deploy_dir && tar xzf $deploy_dir/actions-runner.tar.gz
 
 $deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir


### PR DESCRIPTION
Previously, the curl command outputs an empty `tar.gz` file. Now it works and downloads the correct runner archive.