### PR TITLE
Correctly remove tokens on error for Buildkite

### DIFF
--- a/Buildkite/scripts/bootstrap.sh
+++ b/Buildkite/scripts/bootstrap.sh
@@ -11,9 +11,11 @@ trap 'buildkite-hook "pre-exit" "$BUILDKITE_HOOKS_PATH/pre-exit"' EXIT
 echo "~~~ Deploying ephemeral agent"
 
 token=$(curl -m 60 -sd '{"email":'\"$ORKA_USER\"', "password":'\"$ORKA_PASSWORD\"'}' -H "Content-Type: application/json" -X POST $ORKA_ENDPOINT/token | jq -r '.token')
-trap 'revoke_token $token $ORKA_ENDPOINT' EXIT
 
+trap 'revoke_token $token $ORKA_ENDPOINT' ERR
 vm_info=$(curl -m 60 -sd '{"orka_vm_name":'\"$ORKA_VM_NAME\"'}' -H "Content-Type: application/json" -H "Authorization: Bearer $token" -X POST $ORKA_ENDPOINT/resources/vm/deploy)
+revoke_token $token $ORKA_ENDPOINT
+trap '' ERR
 
 errors=$(echo $vm_info | jq -r '.errors[]?.message')
 if [ "$errors" ]; then


### PR DESCRIPTION
We were overriding the Exit trap and the pre-exit hook was never called.
Remove tokens on Err or when no longer needed