### PR TITLE
Update the GitHub integration

### DIFF
--- a/GitHub/multiple-self-hosted-runners.md
+++ b/GitHub/multiple-self-hosted-runners.md
@@ -56,7 +56,7 @@ To set up multiple GitHub Actions runner, you need to:
         * `-r` or `--repository` - (Required) The URL of the GitHub repository you want to attach the runner to.
         * `-rv` or `--runner_version` - (Optional) The version of the runner. If not specified, defaults to `2.284.0`.
         * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specific, defaults to `default`.
-        * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specific, defaults to `macOS`.
+        * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specified, defaults to `macOS`.
         * `-tp` or `--runner_run_type` - (Optional) One of `command` or `service`. Choose `service` if you want the runner to start automatically when the VM starts. Choose `command` if you want to manually start the runner every time the VM starts. If not specified, defaults to `service`.  
         **Note** If you don't specify or you set to `service`, you need to enable automatic login during startup. To do that, follow these [instructions][auto-login].  
         * `-sf` or `--settings_file` - (Optional) Advanced settings file location. Defaults to `{script_dir}/settings.json`. For more information see [here](#advanced-configuration).  

--- a/GitHub/multiple-self-hosted-runners.md
+++ b/GitHub/multiple-self-hosted-runners.md
@@ -54,7 +54,9 @@ To set up multiple GitHub Actions runner, you need to:
         * `-s` or `--ssh_key_location` - (Required) The location on your local machine of the SSH key used to connect to the Orka VMs. By default it is `~/.ssh/id_rsa`.
         * `-t` or `--github_token` - (Required) The GitHub token you obtained in **Step 1**.
         * `-r` or `--repository` - (Required) The URL of the GitHub repository you want to attach the runner to.
-        * `-rv` or `--runner_version` - (Optional) The version of the runner. If not specified, defaults to `2.161.3`.
+        * `-rv` or `--runner_version` - (Optional) The version of the runner. If not specified, defaults to `2.284.0`.
+        * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specific, defaults to `default`.
+        * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specific, defaults to `macOS`.
         * `-tp` or `--runner_run_type` - (Optional) One of `command` or `service`. Choose `service` if you want the runner to start automatically when the VM starts. Choose `command` if you want to manually start the runner every time the VM starts. If not specified, defaults to `service`.  
         **Note** If you don't specify or you set to `service`, you need to enable automatic login during startup. To do that, follow these [instructions][auto-login].  
         * `-sf` or `--settings_file` - (Optional) Advanced settings file location. Defaults to `{script_dir}/settings.json`. For more information see [here](#advanced-configuration).  

--- a/GitHub/scripts/multiple-runners.sh
+++ b/GitHub/scripts/multiple-runners.sh
@@ -14,8 +14,10 @@ runner_count=${RUNNER_COUNT:-1}
 ssh_key_location=${SSH_KEY_LOCATION:-$HOME/.ssh/id_rsa}
 github_token=${GITHUB_TOKEN:-}
 repository=${REPOSITORY:-}
-version=${RUNNER_VERSION:-"2.163.1"}
+version=${RUNNER_VERSION:-"2.284.0"}
 type=${RUNNER_RUN_TYPE:-"service"}
+group=${RUNNER_GROUP:-"default"}
+labels=${RUNNER_LABELS:-"macOS"}
 settings_file=${SETTINGS_FILE:-"${currentDir}/settings.json"}
 
 while [[ "$#" -gt 0 ]]
@@ -53,6 +55,12 @@ case $1 in
     ;;
     -tp|--runner_run_type)
     type=$2
+    ;;
+    -g|--runner_group)
+    group=$2
+    ;;
+    -l|--runner_labels)
+    labels=$2
     ;;
     -sf|--settings_file)
     settings_file=$2
@@ -115,6 +123,8 @@ for i in $(seq 1 $runner_count); do
         RUNNER_NAME=$vm_id
         RUNNER_VERSION=$version
         RUNNER_RUN_TYPE=$type
+        RUNNER_GROUP=$group
+        RUNNER_LABELS=$labels
     )
 
     echo 'Connecting to VM and setting up agent'

--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -5,10 +5,12 @@ set -euo pipefail
 github_token=${GITHUB_TOKEN:-}
 repository=${REPOSITORY:-}
 runner=${RUNNER_NAME:-$(uuidgen)}
-version=${RUNNER_VERSION:-"2.163.1"}
+version=${RUNNER_VERSION:-"2.284.0"}
 type=${RUNNER_RUN_TYPE:-"service"}
 work_dir=${RUNNER_WORK_DIR:-"_work"}
 deploy_dir=${RUNNER_DEPLOY_DIR:-"$HOME/actions-runner"}
+group=${RUNNER_GROUP:-"default"}
+labels=${RUNNER_LABELS:-"macOS"}
 
 while [[ "$#" -gt 0 ]]
 do
@@ -34,6 +36,12 @@ case $1 in
     -d|--runner_deploy_dir)
     deploy_dir=$2
     ;;
+    -g|--runner_group)
+    group=$2
+    ;;
+    -l|--runner_labels)
+    labels=$2
+    ;;
 esac
 shift
 done
@@ -43,7 +51,7 @@ mkdir $deploy_dir
 curl -o $deploy_dir/actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v$version/actions-runner-osx-x64-$version.tar.gz
 cd $deploy_dir && tar xzf $deploy_dir/actions-runner.tar.gz
 
-$deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir
+$deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir --runnergroup $group --labels $labels
 
 if [[ "$type" == "service" ]]; then
     echo "Installing service"

--- a/GitHub/single-self-hosted-runner.md
+++ b/GitHub/single-self-hosted-runner.md
@@ -31,7 +31,7 @@ To set up a GitHub Actions runner, you need to:
     **Note** If you don't specify or you set to `service`, you need to enable automatic login during startup. To do that, follow these [instructions][auto-login].
     * `-w` or `--runner_work_dir` - (Optional) Runner working directory. If not specified, defaults to `_work` under the runner installation directory.
     * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specified, defaults to `default`.
-    * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specific, defaults to `macOS`.
+    * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specified, defaults to `macOS`.
     * `-d` or `--runner_deploy_dir` - (Optional) Runner installation directory. If not specified, defaults to `actions-runner` under the user home directory.
 
 ## Environment variables

--- a/GitHub/single-self-hosted-runner.md
+++ b/GitHub/single-self-hosted-runner.md
@@ -30,6 +30,8 @@ To set up a GitHub Actions runner, you need to:
     * `-tp` or `--runner_run_type` - (Optional) One of `command` or `service`. Choose `service` if you want the runner to start automatically when the VM starts. Choose `command` if you want to manually start the runner every time the VM starts. If not specified, defaults to `service`.  
     **Note** If you don't specify or you set to `service`, you need to enable automatic login during startup. To do that, follow these [instructions][auto-login].
     * `-w` or `--runner_work_dir` - (Optional) Runner working directory. If not specified, defaults to `_work` under the runner installation directory.
+    * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specific, defaults to `default`.
+    * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specific, defaults to `macOS`.
     * `-d` or `--runner_deploy_dir` - (Optional) Runner installation directory. If not specified, defaults to `actions-runner` under the user home directory.
 
 ## Environment variables

--- a/GitHub/single-self-hosted-runner.md
+++ b/GitHub/single-self-hosted-runner.md
@@ -30,7 +30,7 @@ To set up a GitHub Actions runner, you need to:
     * `-tp` or `--runner_run_type` - (Optional) One of `command` or `service`. Choose `service` if you want the runner to start automatically when the VM starts. Choose `command` if you want to manually start the runner every time the VM starts. If not specified, defaults to `service`.  
     **Note** If you don't specify or you set to `service`, you need to enable automatic login during startup. To do that, follow these [instructions][auto-login].
     * `-w` or `--runner_work_dir` - (Optional) Runner working directory. If not specified, defaults to `_work` under the runner installation directory.
-    * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specific, defaults to `default`.
+    * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specified, defaults to `default`.
     * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specific, defaults to `macOS`.
     * `-d` or `--runner_deploy_dir` - (Optional) Runner installation directory. If not specified, defaults to `actions-runner` under the user home directory.
 


### PR DESCRIPTION
The integration now accepts labels and groups.
Without them we are unable to automate the registration of the runner.