### PR TITLE
Updated setup-runner.sh file

### DIFF
--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -54,7 +54,7 @@ esac
 shift
 done
 
-mkdir $deploy_dir
+mkdir -p $deploy_dir
 
 curl -o $deploy_dir/actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v$version/actions-runner-osx-x64-$version.tar.gz
 cd $deploy_dir && tar xzf $deploy_dir/actions-runner.tar.gz

--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -59,15 +59,16 @@ mkdir -p $deploy_dir
 curl -o $deploy_dir/actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v$version/actions-runner-osx-x64-$version.tar.gz
 cd $deploy_dir && tar xzf $deploy_dir/actions-runner.tar.gz
 
-if [[ $ephemeral = "false" ]]
-then
-    $deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir --runnergroup $group --labels $labels
-elif [[ $ephemeral = "true" ]]
-then
-    $deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir --runnergroup $group --labels $labels --ephemeral
+config_command="$deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir --runnergroup $group --labels $labels"
+
+if [[ $ephemeral == "true" ]]; then
+    config_command="$config_command --ephemeral"
 else
     echo "Invalid input for the ephemeral tag."
+    exit 1
 fi
+
+eval $config_command
 
 if [[ "$type" == "service" ]]; then
     echo "Installing service"

--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -63,12 +63,13 @@ config_command="$deploy_dir/config.sh --url $repository --token $github_token --
 
 if [[ $ephemeral == "true" ]]; then
     config_command="$config_command --ephemeral"
+    eval $config_command
+elif [[ $ephemeral == "false" ]]; then
+    eval $config_command
 else
     echo "Invalid input for the ephemeral tag."
     exit 1
 fi
-
-eval $config_command
 
 if [[ "$type" == "service" ]]; then
     echo "Installing service"

--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -63,13 +63,14 @@ config_command="$deploy_dir/config.sh --url $repository --token $github_token --
 
 if [[ $ephemeral == "true" ]]; then
     config_command="$config_command --ephemeral"
-    eval $config_command
 elif [[ $ephemeral == "false" ]]; then
-    eval $config_command
+    :
 else
     echo "Invalid input for the ephemeral tag."
     exit 1
 fi
+
+eval $config_command
 
 if [[ "$type" == "service" ]]; then
     echo "Installing service"

--- a/GitHub/scripts/setup-runner.sh
+++ b/GitHub/scripts/setup-runner.sh
@@ -56,7 +56,7 @@ done
 
 mkdir -p $deploy_dir
 
-curl -o $deploy_dir/actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v$version/actions-runner-osx-x64-$version.tar.gz
+curl -o $deploy_dir/actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v$version/actions-runner-osx-$cpu-$version.tar.gz
 cd $deploy_dir && tar xzf $deploy_dir/actions-runner.tar.gz
 
 config_command="$deploy_dir/config.sh --url $repository --token $github_token --name $runner --work $work_dir --runnergroup $group --labels $labels"

--- a/GitHub/single-self-hosted-runner.md
+++ b/GitHub/single-self-hosted-runner.md
@@ -26,13 +26,15 @@ To set up a GitHub Actions runner, you need to:
     * `-t` or `--github_token` - (Required) The GitHub token you obtained in **Step 1**.
     * `-r` or `--repository` - (Required) The URL of the GitHub repository you want to attach the runner to.
     * `-n` or `--runner_name` - (Optional) A name for the runner. If not specified, defaults to a custom GUID.
-    * `-v` or `--runner_version` - (Optional) The version of the runner. If not specified, defaults to `2.160.2`.
+    * `-v` or `--runner_version` - (Optional) The version of the runner. If not specified, defaults to `2.299.1`.
     * `-tp` or `--runner_run_type` - (Optional) One of `command` or `service`. Choose `service` if you want the runner to start automatically when the VM starts. Choose `command` if you want to manually start the runner every time the VM starts. If not specified, defaults to `service`.  
     **Note** If you don't specify or you set to `service`, you need to enable automatic login during startup. To do that, follow these [instructions][auto-login].
     * `-w` or `--runner_work_dir` - (Optional) Runner working directory. If not specified, defaults to `_work` under the runner installation directory.
     * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specified, defaults to `default`.
     * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specified, defaults to `macOS`.
     * `-d` or `--runner_deploy_dir` - (Optional) Runner installation directory. If not specified, defaults to `actions-runner` under the user home directory.
+    * `-c` or `--cpu` - (Optional) One of `x64` or `arm64`. Choose `x64` if the node has an Intel cpu. Choose `arm64` if the node has an Apple Silicon cpu. If not specified, defaults to `x64`.
+    * `-e` or `--ephemeral` - (Optional) One of `true` or `false`. Choose `true` if you want the runner to be ephemeral. Choose `false` if you want the runner to be persistent. If not specified, defaults to `false`.
 
 ## Environment variables
 


### PR DESCRIPTION
Added an optional tag to designate CPU architecture to allow runners to be deployed on M1 nodes.

Added an optional tag to designate if the runner should be ephemeral, some clients don't want persistent runners.

Updated script to use GitHub Actions version 2.299.1 as the version that was used did not have an option for arm64.