### PR TITLE
Add logic to pass CPU type when setting up multiple runners

### DIFF
--- a/GitHub/multiple-self-hosted-runners.md
+++ b/GitHub/multiple-self-hosted-runners.md
@@ -54,6 +54,7 @@ To set up multiple GitHub Actions runner, you need to:
         * `-s` or `--ssh_key_location` - (Required) The location on your local machine of the SSH key used to connect to the Orka VMs. By default it is `~/.ssh/id_rsa`.
         * `-t` or `--github_token` - (Required) The GitHub token you obtained in **Step 1**.
         * `-r` or `--repository` - (Required) The URL of the GitHub repository you want to attach the runner to.
+        * `-cpu` or `--cpu-type` - (Required) Either x64 or arm64, depending if running on Intel or Apple Silicon nodes
         * `-rv` or `--runner_version` - (Optional) The version of the runner. If not specified, defaults to `2.284.0`.
         * `-g` or `--runner-group` - (Optional) The group the runner is assigned to. If not specific, defaults to `default`.
         * `-l` or `--runner-labels` - (Optional) The additional labels of the runner. If not specified, defaults to `macOS`.
@@ -72,6 +73,7 @@ You can also use environment variables instead of passing arguments to the [mult
 * `ORKA_VM_USER`
 * `RUNNER_COUNT`
 * `SSH_KEY_LOCATION`
+* `CPU_TYPE`
 * `GITHUB_TOKEN`
 * `REPOSITORY`
 * `RUNNER_NAME`

--- a/GitHub/scripts/multiple-runners.sh
+++ b/GitHub/scripts/multiple-runners.sh
@@ -14,10 +14,11 @@ runner_count=${RUNNER_COUNT:-1}
 ssh_key_location=${SSH_KEY_LOCATION:-$HOME/.ssh/id_rsa}
 github_token=${GITHUB_TOKEN:-}
 repository=${REPOSITORY:-}
-version=${RUNNER_VERSION:-"2.284.0"}
+version=${RUNNER_VERSION:-"2.307.1"}
 type=${RUNNER_RUN_TYPE:-"service"}
 group=${RUNNER_GROUP:-"default"}
 labels=${RUNNER_LABELS:-"macOS"}
+cpu=${CPU_TYPE:-}
 settings_file=${SETTINGS_FILE:-"${currentDir}/settings.json"}
 deploy_timeout=${DEPLOY_TIMEOUT:-60}
 
@@ -51,6 +52,9 @@ case $1 in
     -r|--repository)
     repository=$2
     ;;
+    -cpu|--cpu_type)
+    cpu=$2
+    ;;
     -rv|--runner_version)
     version=$2
     ;;
@@ -76,6 +80,8 @@ done
 token=$(curl -m 60 -sd '{"email":'\"$orka_user\"', "password":'\"$orka_password\"'}' -H "Content-Type: application/json" -X POST $orka_endpoint/token | jq -r '.token')
 
 trap 'handle_exit $token $orka_endpoint' EXIT
+echo "Version: $version"
+echo "CPU Type: $cpu"
 
 for i in $(seq 1 $runner_count); do
     echo "Booting VM #$i"
@@ -129,6 +135,7 @@ for i in $(seq 1 $runner_count); do
         RUNNER_RUN_TYPE=$type
         RUNNER_GROUP=$group
         RUNNER_LABELS=$labels
+        CPU_TYPE=$cpu
     )
 
     echo 'Connecting to VM and setting up agent'


### PR DESCRIPTION
Added another flag to the command for multiple-runners.sh to allow passing of the CPU_TYPE to the setup-runner.sh script. Without this, one would need to manually set the CPU in the setup-runner.sh script in order to use the multiple-runners script. I've updated the readme for multiple-runners as well to account for this new flag.