### PR TITLE
Provide cpu flag for multiple runners script

### DIFF
--- a/GitHub/multiple-self-hosted-runners.md
+++ b/GitHub/multiple-self-hosted-runners.md
@@ -57,6 +57,7 @@ To set up multiple GitHub Actions runner, you need to:
         * `-l` or `--runner-labels` - (Optional) The additional labels of the runner, as a comma-separated list. If not specified, defaults to `macOS`.
         * `-tp` or `--runner_run_type` - (Optional) One of `command` or `service`. Choose `service` if you want the runner to start automatically when the VM starts. Choose `command` if you want to manually start the runner every time the VM starts. If not specified, defaults to `service`.  
         **Note** If you don't specify or you set to `service`, you need to enable automatic login during startup. To do that, follow these [instructions][auto-login].  
+        * `-c` or `--cpu` - (Optional) One of `x64` or `arm64`. Choose `x64` if the host has an Intel cpu. Choose `arm64` if the host has an Apple Silicon cpu. If not specified, defaults to `x64`.
         * `-sf` or `--settings_file` - (Optional) Advanced settings file location. Defaults to `{script_dir}/settings.json`. For more information see [here](#advanced-configuration).  
 
 ## Environment variables

--- a/GitHub/scripts/multiple-runners.sh
+++ b/GitHub/scripts/multiple-runners.sh
@@ -16,6 +16,7 @@ version=${RUNNER_VERSION:-"2.284.0"}
 type=${RUNNER_RUN_TYPE:-"service"}
 group=${RUNNER_GROUP:-"default"}
 labels=${RUNNER_LABELS:-"macOS"}
+cpu=${CPU_TYPE:-"x64"}
 settings_file=${SETTINGS_FILE:-"${currentDir}/settings.json"}
 
 while [[ "$#" -gt 0 ]]
@@ -53,6 +54,9 @@ case $1 in
       ;;
     -l|--runner_labels)
       labels=$2
+      ;;
+    -c|--cpu)
+      cpu=$2
       ;;
     -sf|--settings_file)
       settings_file=$2
@@ -135,6 +139,7 @@ for r in $(seq 1 "$runner_count"); do
         RUNNER_RUN_TYPE="$type"
         RUNNER_GROUP="$group"
         RUNNER_LABELS="$labels"
+        CPU_TYPE="$cpu"
     )
 
     echo 'Connecting to VM and setting up agent'


### PR DESCRIPTION
This PR adds `--cpu` flag to the multiple runners script.

Currently, the script fails if it is executed on an arm host with the following error:

<img width="858" alt="Screenshot 2023-11-08 at 10 49 14" src="https://github.com/macstadium/orka-integrations/assets/760518/3f63655f-e14a-4eae-af35-c864738c6359">
