### PR TITLE
[gitlab] Handle vm deploy errors properly

### DIFF
--- a/Buildkite/scripts/bootstrap.sh
+++ b/Buildkite/scripts/bootstrap.sh
@@ -19,7 +19,7 @@ orka3 config set --api-url "$ORKA_ENDPOINT"
 orka3 user set-token "$ORKA_TOKEN"
 
 set +e
-vm_info=$(orka3 vm deploy --config "$ORKA_CONFIG_NAME" --generate-name "$ORKA_VM_NAME_PREFIX" -o json 2>&1)
+vm_info=$(orka3 vm deploy "$ORKA_VM_NAME_PREFIX" --config "$ORKA_CONFIG_NAME" --generate-name -o json 2>&1)
 if [ $? -ne 0 ]; then
     echo "VM deploy failed with $vm_info" 1>&2
     exit 1

--- a/GitHub/scripts/multiple-runners.sh
+++ b/GitHub/scripts/multiple-runners.sh
@@ -88,7 +88,7 @@ for r in $(seq 1 "$runner_count"); do
     echo "Booting VM #$r..."
 
     set +e
-    vm_info=$(orka3 vm deploy --config "$orka_config_name" --generate-name "$orka_vm_name_prefix" -o json 2>&1)
+    vm_info=$(orka3 vm deploy "$orka_vm_name_prefix" --config "$orka_config_name" --generate-name -o json 2>&1)
     if [ $? -ne 0 ]; then
         echo "VM deploy failed with $vm_info" 1>&2
         exit 1

--- a/GitLab/scripts/prepare.sh
+++ b/GitLab/scripts/prepare.sh
@@ -17,13 +17,7 @@ echo "Authenticated."
 
 echo "Deploying a VM..."
 
-set +e
-vm_info=$(orka3 vm deploy --config "$ORKA_CONFIG_NAME" --generate-name "$ORKA_VM_NAME_PREFIX" -o json 2>&1)
-if [ $? -ne 0 ]; then
-    echo "VM deploy failed with $vm_info" 1>&2
-    exit 1
-fi
-set -e
+vm_info=$(orka3 vm deploy --config "$ORKA_CONFIG_NAME" --generate-name "$ORKA_VM_NAME_PREFIX" -o json)
 
 vm_name=$(echo "$vm_info" | jq -r '.[0]|.name')
 

--- a/GitLab/scripts/prepare.sh
+++ b/GitLab/scripts/prepare.sh
@@ -17,7 +17,7 @@ echo "Authenticated."
 
 echo "Deploying a VM..."
 
-vm_info=$(orka3 vm deploy --config "$ORKA_CONFIG_NAME" --generate-name "$ORKA_VM_NAME_PREFIX" -o json)
+vm_info=$(orka3 vm deploy "$ORKA_VM_NAME_PREFIX" --config "$ORKA_CONFIG_NAME" --generate-name -o json)
 
 vm_name=$(echo "$vm_info" | jq -r '.[0]|.name')
 


### PR DESCRIPTION
As you can see on the screen shot there is no error message, when the VM Deploy fails:
<img width="1980" alt="image" src="https://github.com/macstadium/orka-integrations/assets/17491481/1ebdf501-fa74-4ac1-b1dc-56a37f166c7a">



Example run with the fix when the provided token is not valid:
<img width="1979" alt="image" src="https://github.com/macstadium/orka-integrations/assets/17491481/563cce9d-e605-4069-a5e9-2cfc0bf826de">

Even though we had the `set +e` the code in the if statement did not execute, because of the `trap` statement from above.

Here's what actually happended

If `orka3 vm deploy` fails, the script will not exit immediately due to set +e. Instead, it will continue to the next command.
However, before moving to the next command, the shell will first execute the function specified in your trap statement - `system_failure`, which will exit the scripts. That's why we were not seeing the error messages. 

Now instead of handling the error, we can directly rely on the trap handler to execute if `vm deploy` fails. 