### PR TITLE
Deprecate and remove support

### DIFF
--- a/GitHub/README.md
+++ b/GitHub/README.md
@@ -1,4 +1,13 @@
-# Orka-GitHub Actions Integration
+[!CAUTION] 
+# Deprecation Alert May 6, 2024
+
+This Github Actions Integration is now deprecated in favor of the new [one](https://github.com/macstadium/orka-github-actions-integration/).
+
+# Official Support Deprecation
+
+As of May 6, 2024 this folder is no longer officially supported. The code owner will still maintain and provide long term support, without official guarantee.
+
+## Orka-GitHub Actions Integration
 
 The Orka-GitHub Actions integration provides guides on how to use [Orka by MacStadium][orka] in a GitHub Actions workflow.  
 You can find guides on how to set up [multiple runners automatically](multiple-self-hosted-runners.md), [a single runner automatically](single-self-hosted-runner.md) and [a single runner manually](self-hosted-runner-manually.md).

--- a/GitHub/README.md
+++ b/GitHub/README.md
@@ -1,11 +1,8 @@
-[!CAUTION] 
-# Deprecation Alert May 6, 2024
-
-This Github Actions Integration is now deprecated in favor of the new [one](https://github.com/macstadium/orka-github-actions-integration/).
-
 # Official Support Deprecation
 
-As of May 6, 2024 this folder is no longer officially supported. The code owner will still maintain and provide long term support, without official guarantee.
+## May 6, 2024
+
+As of May 6, 2024 this Github Actions Integration is no longer officially supported and is now deprecated in favor of the new [one](https://github.com/macstadium/orka-github-actions-integration/). The code owner will still maintain and provide long term support, without official guarantee.
 
 ## Orka-GitHub Actions Integration
 


### PR DESCRIPTION
We plan to move all support and development efforts to the new GHA integration. This PR officially freezes the old integration for minimal LTS. 