### PR TITLE
[GitLab] Export KUBECONFIG environment variable

### DIFF
--- a/GitLab/Dockerfile
+++ b/GitLab/Dockerfile
@@ -14,5 +14,8 @@ RUN wget "https://cli-builds-public.s3.eu-west-1.amazonaws.com/official/${ORKA_C
 
 COPY scripts /var/custom-executor
 
+# We need to export this environment variable here to ensure that the runner can be automatically deployed into a Kubernetes cluster.
+ENV KUBECONFIG=/root/.kube/config
+
 ENTRYPOINT ["dumb-init", "/var/custom-executor/start.sh"]
 CMD ["run", "--user=gitlab-runner", "--working-directory=/home/gitlab-runner"]


### PR DESCRIPTION
In case the runner is deployed into a Kubernetes cluster, we need to export the KUBECONFIG environment variable. Otherwise, the orka3 CLI picks up the InClusterConfig of the pod it is deployed on and connects to the wrong cluster.