### PR TITLE
[GitLab] Improve error handling for custom runner script

### DIFF
--- a/GitLab/scripts/base.sh
+++ b/GitLab/scripts/base.sh
@@ -46,6 +46,12 @@ function valid_ip {
     return 255
 }
 
+# https://docs.gitlab.com/runner/executors/custom/#build-failure
+function build_failure {
+    exit "$BUILD_FAILURE_EXIT_CODE"
+}
+
+# https://docs.gitlab.com/runner/executors/custom/#system-failure
 function system_failure {
     if [ $? -eq 28 ]; then
         echo "Curl operation timed out. Exiting..."

--- a/GitLab/scripts/run.sh
+++ b/GitLab/scripts/run.sh
@@ -13,5 +13,8 @@ IFS=';' read -ra info <<< "$connection_info"
 vm_ip=${info[0]}
 vm_ssh_port=${info[1]}
 
+# Treat failure of user script execution as build failure instead of system failure
+trap - ERR
+
 ssh -i "$ORKA_SSH_KEY_FILE" \
-  -o ServerAliveInterval=60 -o ServerAliveCountMax=60 "$ORKA_VM_USER@$vm_ip" -p "$vm_ssh_port" /bin/bash < "${1}"
+  -o ServerAliveInterval=60 -o ServerAliveCountMax=60 "$ORKA_VM_USER@$vm_ip" -p "$vm_ssh_port" /bin/bash < "${1}" || build_failure


### PR DESCRIPTION
User script execution failures should be classified as build failures rather than system failures.

In the current implementation of `run.sh`, any job failure causes GitLab to display a system failure error message at the top of the job log, which misrepresents the nature of the failure: 

<img width="620" height="116" alt="Screenshot 2025-07-23 at 15 53 49" src="https://github.com/user-attachments/assets/93fdc078-b4f3-484f-9def-ae84c35b83db" />
